### PR TITLE
Fixed hdmi bug with frambuffer buffer overflow

### DIFF
--- a/BUFFER/FILE/OrangePiH5_PC2_sys_config.fex
+++ b/BUFFER/FILE/OrangePiH5_PC2_sys_config.fex
@@ -493,23 +493,23 @@ screen0_output_mode      = 4
 screen1_output_type      = 2
 screen1_output_mode      = 11
 
-dev0_output_type = 4
-dev0_output_mode = 4
-dev0_screen_id = 0
-dev0_do_hpd = 1
+dev0_output_type = 0
+;dev0_output_mode = 4
+;dev0_screen_id = 0
+;dev0_do_hpd = 1
 
-dev1_output_type = 2
-dev1_output_mode = 11
-dev1_screen_id = 1
-dev1_do_hpd = 1
+dev1_output_type = 0
+;dev1_output_mode = 11
+;dev1_screen_id = 1
+;dev1_do_hpd = 1
 
 dev2_output_type = 0
 def_output_dev = 0
 hdmi_mode_check = 1
 
 fb0_format               = 0
-fb0_width                = 1280
-fb0_height               = 720
+fb0_width                = 0
+fb0_height               = 0
 
 fb1_format               = 0
 fb1_width                = 0

--- a/BUFFER/FILE/OrangePiH5_Prima_sys_config.fex
+++ b/BUFFER/FILE/OrangePiH5_Prima_sys_config.fex
@@ -494,23 +494,23 @@ screen0_output_mode      = 4
 screen1_output_type      = 2
 screen1_output_mode      = 11
 
-dev0_output_type = 4
-dev0_output_mode = 4
-dev0_screen_id = 0
-dev0_do_hpd = 1
+dev0_output_type = 0
+;dev0_output_mode = 4
+;dev0_screen_id = 0
+;dev0_do_hpd = 1
 
-dev1_output_type = 2
-dev1_output_mode = 11
-dev1_screen_id = 1
-dev1_do_hpd = 1
+dev1_output_type = 0
+;dev1_output_mode = 11
+;dev1_screen_id = 1
+;dev1_do_hpd = 1
 
 dev2_output_type = 0
 def_output_dev = 0
 hdmi_mode_check = 1
 
 fb0_format               = 0
-fb0_width                = 1280
-fb0_height               = 720
+fb0_width                = 0
+fb0_height               = 0
 
 fb1_format               = 0
 fb1_width                = 0

--- a/BUFFER/FILE/OrangePiH5_Zero_Plus2_sys_config.fex
+++ b/BUFFER/FILE/OrangePiH5_Zero_Plus2_sys_config.fex
@@ -491,23 +491,23 @@ screen0_output_mode      = 4
 screen1_output_type      = 2
 screen1_output_mode      = 11
 
-dev0_output_type = 4
-dev0_output_mode = 4
-dev0_screen_id = 0
-dev0_do_hpd = 1
+dev0_output_type = 0
+;dev0_output_mode = 4
+;dev0_screen_id = 0
+;dev0_do_hpd = 1
 
-dev1_output_type = 2
-dev1_output_mode = 11
-dev1_screen_id = 1
-dev1_do_hpd = 1
+dev1_output_type = 0
+;dev1_output_mode = 11
+;dev1_screen_id = 1
+;dev1_do_hpd = 1
 
 dev2_output_type = 0
 def_output_dev = 0
 hdmi_mode_check = 1
 
 fb0_format               = 0
-fb0_width                = 1280
-fb0_height               = 720
+fb0_width                = 0
+fb0_height               = 0
 
 fb1_format               = 0
 fb1_width                = 0

--- a/sys_config/OrangePiH5_PC2_sys_config.fex
+++ b/sys_config/OrangePiH5_PC2_sys_config.fex
@@ -493,23 +493,23 @@ screen0_output_mode      = 4
 screen1_output_type      = 2
 screen1_output_mode      = 11
 
-dev0_output_type = 4
-dev0_output_mode = 4
-dev0_screen_id = 0
-dev0_do_hpd = 1
+dev0_output_type = 0
+;dev0_output_mode = 4
+;dev0_screen_id = 0
+;dev0_do_hpd = 1
 
-dev1_output_type = 2
-dev1_output_mode = 11
-dev1_screen_id = 1
-dev1_do_hpd = 1
+dev1_output_type = 0
+;dev1_output_mode = 11
+;dev1_screen_id = 1
+;dev1_do_hpd = 1
 
 dev2_output_type = 0
 def_output_dev = 0
 hdmi_mode_check = 1
 
 fb0_format               = 0
-fb0_width                = 1280
-fb0_height               = 720
+fb0_width                = 0
+fb0_height               = 0
 
 fb1_format               = 0
 fb1_width                = 0

--- a/sys_config/OrangePiH5_Prima_sys_config.fex
+++ b/sys_config/OrangePiH5_Prima_sys_config.fex
@@ -494,23 +494,23 @@ screen0_output_mode      = 4
 screen1_output_type      = 2
 screen1_output_mode      = 11
 
-dev0_output_type = 4
-dev0_output_mode = 4
-dev0_screen_id = 0
-dev0_do_hpd = 1
+dev0_output_type = 0
+;dev0_output_mode = 4
+;dev0_screen_id = 0
+;dev0_do_hpd = 1
 
-dev1_output_type = 2
-dev1_output_mode = 11
-dev1_screen_id = 1
-dev1_do_hpd = 1
+dev1_output_type = 0
+;dev1_output_mode = 11
+;dev1_screen_id = 1
+;dev1_do_hpd = 1
 
 dev2_output_type = 0
 def_output_dev = 0
 hdmi_mode_check = 1
 
 fb0_format               = 0
-fb0_width                = 1280
-fb0_height               = 720
+fb0_width                = 0
+fb0_height               = 0
 
 fb1_format               = 0
 fb1_width                = 0

--- a/sys_config/OrangePiH5_Zero_Plus2_sys_config.fex
+++ b/sys_config/OrangePiH5_Zero_Plus2_sys_config.fex
@@ -491,23 +491,23 @@ screen0_output_mode      = 4
 screen1_output_type      = 2
 screen1_output_mode      = 11
 
-dev0_output_type = 4
-dev0_output_mode = 4
-dev0_screen_id = 0
-dev0_do_hpd = 1
+dev0_output_type = 0
+;dev0_output_mode = 4
+;dev0_screen_id = 0
+;dev0_do_hpd = 1
 
-dev1_output_type = 2
-dev1_output_mode = 11
-dev1_screen_id = 1
-dev1_do_hpd = 1
+dev1_output_type = 0
+;dev1_output_mode = 11
+;dev1_screen_id = 1
+;dev1_do_hpd = 1
 
 dev2_output_type = 0
 def_output_dev = 0
 hdmi_mode_check = 1
 
 fb0_format               = 0
-fb0_width                = 1280
-fb0_height               = 720
+fb0_width                = 0
+fb0_height               = 0
 
 fb1_format               = 0
 fb1_width                = 0


### PR DESCRIPTION
Fixed hdmi bug with frambuffer buffer overflow(on the dev0_output with hpd enable of hdmi)

There are some details:
When change the screen0_output_mode to "0xa" (The 1080p60 Resolution)  on device tree(sys_config.fex) and reboot,It will cause the cpu softlock Or unplug the hdmi cable on boot,It turn be normal.

There are some log:
![1](https://user-images.githubusercontent.com/17332156/63846252-036daf80-c9be-11e9-943f-c5d374327900.png)
![2](https://user-images.githubusercontent.com/17332156/63846253-04064600-c9be-11e9-9325-ffe726aa894b.png)
![3](https://user-images.githubusercontent.com/17332156/63846257-04064600-c9be-11e9-94c6-974fb96c5d26.png)

disable the dev0_output or dev0_do_hpd can fix it.